### PR TITLE
Force JSON formatter in RSpec call.

### DIFF
--- a/lib/rspec-launcher-command.coffee
+++ b/lib/rspec-launcher-command.coffee
@@ -12,7 +12,7 @@ class RSpecLauncherCommand
 
     rspecCommandPath = atom.config.get('rspec-tree-runner.rspecPathCommand')
 
-    command = "#{rspecCommandPath} #{file}"
+    command = "#{rspecCommandPath} --format=json #{file}"
 
     @terminalCommandRunner.onDataFinished (data) => @parseRSpecResult(data)
 

--- a/spec/rspec-launcher-command-spec.coffee
+++ b/spec/rspec-launcher-command-spec.coffee
@@ -9,7 +9,7 @@ describe 'RSpecLauncherCommand', ->
 
     spyOn(atom.project, 'getPaths').andReturn(['a', 'b'])
 
-    atom.config.set('rspec-tree-runner.rspecPathCommand', 'rspec --format j')
+    atom.config.set('rspec-tree-runner.rspecPathCommand', 'rspec')
 
     terminalCommandRunner = new TerminalCommandRunner
 
@@ -23,4 +23,4 @@ describe 'RSpecLauncherCommand', ->
 
   it 'runs the command', ->
     expect(terminalCommandRunner.run)
-      .toHaveBeenCalledWith('rspec --format j somefile', 'a')
+      .toHaveBeenCalledWith('rspec --format=json somefile', 'a')


### PR DESCRIPTION
- Update `rspec-launcher-command.coffee` to specify the `--format=json` flag before the filename, overriding the user's configuration.
- Update launcher spec to match new command.
