### PR TITLE
Add 'run single test' feature (issue #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This package finds the corresponding tests for your file, displaying the hierarc
 ## How to use it
 HotKeys:
 - __Ctrl+Alt+L__ - Activate the package
-- __Ctrl+Alt+X__ - Executes test
+- __Ctrl+Alt+X__ - Executes all test
+- __Ctrl+Alt+X__ - Executes single test (current line)
 - __Ctrl+Alt+Q__ - Toggles between files and tests
 
 To activate the package press ctrl-alt-l.

--- a/keymaps/rspec-tree-runner.cson
+++ b/keymaps/rspec-tree-runner.cson
@@ -11,3 +11,4 @@
   'ctrl-alt-l': 'rspec-tree-runner:toggle'
   'ctrl-alt-q': 'rspec-tree-runner:toggle-spec-file'
   'ctrl-alt-x': 'rspec-tree-runner:run-tests'
+  'ctrl-alt-r': 'rspec-tree-runner:run-single-test'

--- a/lib/ast-parser.coffee
+++ b/lib/ast-parser.coffee
@@ -9,7 +9,7 @@ class AstParser
     @tree
 
   addChildren: (result, currentOld) ->
-    types = ['describe', 'context', 'it']
+    types = ['describe', 'context', 'it', 'feature', 'scenario']
 
     if currentOld.type in types
       newNode = {

--- a/lib/plugin-state.coffee
+++ b/lib/plugin-state.coffee
@@ -23,6 +23,9 @@ class PluginState
     if ((!editor) || (!editor.buffer))
       @setNullState()
     else
+
+      @cursor = editor.cursors[0]
+
       @currentFilePath = editor.buffer.file.path
 
       @currentFilePathExtension = @currentFilePath.split('.').pop();
@@ -63,6 +66,7 @@ class PluginState
     @currentFilePath = null
     @currentCorrespondingFilePath = null
     @specFileToAnalyze = null
+    @specRowToAnalyze = null
     @specFileExists = null
     @specFileToAnalyzeWithoutProjectRoot = null
 
@@ -78,6 +82,17 @@ class PluginState
     @emitter.emit 'onTestsRunning'
 
     @rspecLauncherCommand.run(@specFileToAnalyze)
+
+  runSingleTest: ->
+    return unless @specFileToAnalyze?
+
+    return unless @specFileExists
+
+    @specRowToAnalyze = @cursor.getBufferRow() + 1
+
+    @emitter.emit 'onTestsRunning'
+
+    @rspecLauncherCommand.run(@specFileToAnalyze + ":" + @specRowToAnalyze)
 
   updateTreeWithTests: (results, stdErrorData) ->
     asTree = @treeBuilder.updateWithTests(results)

--- a/lib/rspec-tree-runner.coffee
+++ b/lib/rspec-tree-runner.coffee
@@ -48,6 +48,8 @@ module.exports =
 
     @subscriptions.add atom.commands.add 'atom-workspace', 'rspec-tree-runner:run-tests': => @mainView.runTests()
 
+    @subscriptions.add atom.commands.add 'atom-workspace', 'rspec-tree-runner:run-single-test': => @mainView.runSingleTest()
+
   deactivate: ->
     @modalPanel.destroy()
     @subscriptions.dispose()

--- a/lib/rspec-tree-view.coffee
+++ b/lib/rspec-tree-view.coffee
@@ -30,6 +30,7 @@ class RSpecTreeView extends View
             @div class: 'number', '-'
             @div class: 'text', 'pending'
       @h3 class: 'run-tests-hint hint', ''
+      @h3 class: 'run-single-test-hint hint', ''
       @h3 class: 'toggle-file-hint hint', ''
       @div class: 'rspec-tree-runner-view-container'
 
@@ -190,6 +191,11 @@ class RSpecTreeView extends View
 
     @currentState.runTests()
 
+  runSingleTest: ->
+    return unless @currentState.specFileExists
+
+    @currentState.runSingleTest()
+
   toggleSpecFile: ->
     atom.workspace.open(@currentState.currentCorrespondingFilePath) if @currentState.currentCorrespondingFilePath?
 
@@ -224,13 +230,16 @@ class RSpecTreeView extends View
   prepareKeyStrokesText: ->
     toggleSpecFileKeyBindings = atom.keymaps.findKeyBindings({command:'rspec-tree-runner:toggle-spec-file' })
     runTestsKeyBindings = atom.keymaps.findKeyBindings({command:'rspec-tree-runner:run-tests' })
-    
+    runSingleTestKeyBindings = atom.keymaps.findKeyBindings({command:'rspec-tree-runner:run-single-test' })
+
     toggleSpecFileKeyStroke = if (toggleSpecFileKeyBindings and toggleSpecFileKeyBindings.length > 0) then toggleSpecFileKeyBindings[0].keystrokes else 'not def'
 
     runTestsKeyStroke = if (runTestsKeyBindings and runTestsKeyBindings.length > 0) then runTestsKeyBindings[0].keystrokes else 'not def'
+    runSingleTestKeyStroke = if (runSingleTestKeyBindings and runSingleTestKeyBindings.length > 0) then runSingleTestKeyBindings[0].keystrokes else 'not def'
 
-    this.find('.toggle-file-hint').html("Press #{toggleSpecFileKeyStroke} to toggle/create")
+    this.find('h3.toggle-file-hint').html("Press #{toggleSpecFileKeyStroke} to toggle/create")
     this.find('h3.run-tests-hint').html("Press #{runTestsKeyStroke} to run tests")
+    this.find('h3.run-single-test-hint').html("Press #{runSingleTestKeyStroke} to run a single test")
 
   getCurrentBuffer: (editor) ->
     try


### PR DESCRIPTION
What I did:

to run a single test, we just need to pass to rspec command a line number. So, I copied the `runTests` methods and created a `runSingleTest` that get the current cursor (lines 27 and 91 from plugin-state) and then run rspec command with parameters `@specFileToAnalyze + ":" + @specRowToAnalyze` (line 95 of plugin-state).

I also added 'scenario' and 'feature' on the AstParser, so capybara specs will be parsed.
