### PR TITLE
Fix error when resizing subcontainer that does not exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,9 @@ module.exports = {
 		// Quick fix implemented to allow the subContainer to have scroll when
 		// the list of tests is big. I haven't been able to fix it just with CSS.
 		const newHeight = window.innerHeight - 60;
-		document.getElementById('subContainer').style.height = `${newHeight}px`;
+		var subContainer = document.getElementById('subContainer');
+		if (subContainer !== null) {
+			subContainer.style.height = `${newHeight}px`;
+		}
 	}
 };


### PR DESCRIPTION
This PR fixes #22

It was caused when the panel got opened/toggled when the active file is not an rspec file.
In this situation the subContainer element is not available, so the `getElementById('subContainer')` returns `null`
