### PR TITLE
Use correct project path if rspec is not part of 'first project'

### DIFF
--- a/lib/rspec-launcher-command.js
+++ b/lib/rspec-launcher-command.js
@@ -22,7 +22,14 @@ class RSpecLauncherCommand extends EventEmitter {
 		const rspecCommandPath = atom.config.get('rspec-tree-runner.rspecPathCommand');
 		const command = `${rspecCommandPath} --format=json "${file}"`;
 
-		this.terminalCommandRunner.run(command, atom.project.getPaths()[0]);
+		paths = atom.project.getPaths();
+		for (var i = 0; i < paths.length; i++) {
+			path = paths[i];
+			if (file.indexOf(path) === 0) {
+				break;
+			}
+		}
+		this.terminalCommandRunner.run(command, path)
 	}
 	parseRSpecResult(data) {
 		let jsonData;

--- a/spec/rspec-launcher-command-spec.js
+++ b/spec/rspec-launcher-command-spec.js
@@ -21,13 +21,21 @@ describe('RSpecLauncherCommand', () => {
 		rspecLauncherCommand = new RSpecLauncherCommand(
 			jsonSanitizer, terminalCommandRunner);
 
-		rspecLauncherCommand.run('somefile');
 		rspecLauncherCommand.parseRSpecResult({stdOutData: '{}', stdErrorData: ''});
 	});
 
-	it('runs the command', () => {
+	it('runs the command on project a', () => {
+		rspecLauncherCommand.run('a/somefile');
+
 		expect(terminalCommandRunner.run)
-			.toHaveBeenCalledWith('rspec --format=json "somefile"', 'a');
+			.toHaveBeenCalledWith('rspec --format=json "a/somefile"', 'a');
+	});
+
+	it('runs the command on project b', () => {
+		rspecLauncherCommand.run('b/somefile');
+
+		expect(terminalCommandRunner.run)
+			.toHaveBeenCalledWith('rspec --format=json "b/somefile"', 'b');
 	});
 
 	it('calls the sanitizer when parsing data', () => {


### PR DESCRIPTION
This adds support for workspaces that contain multiple projects.
Using index '0' of `atom.project.getPaths()[0]` assumes that the rspec file is part of the top/first project of the workspace.

This PR iterates over the project paths to find which path matches the start of the file path.