### PR TITLE
Support new version of Ruby (2.4.0+)

### DIFF
--- a/spec-analyzer/spec_analyzer_script.rb
+++ b/spec-analyzer/spec_analyzer_script.rb
@@ -53,7 +53,7 @@ module SpecAnalyzer
     end
 
     def try_assign_line(expression, exploration_state)
-      return unless expression.is_a?(Fixnum)
+      return unless expression.is_a?(Integer)
       @line = expression if @line.nil? && exploration_state.assign_type?
     end
   end


### PR DESCRIPTION
Ruby 2.4.0 merged Fixnum and Bignum into Integer.

Note that this breaks support for Ruby <2.4.0.
If we need to support both the Ruby devs provided the [RUBY_INTEGER_UNIFICATION macro](https://bugs.ruby-lang.org/issues/12005).