### PR TITLE
Fix invisible tree

### DIFF
--- a/styles/tests-runner-container.less
+++ b/styles/tests-runner-container.less
@@ -26,6 +26,7 @@
 
   /* the tree node's style */
   .tree-view {
+    contain: none;
     overflow-y: hidden;
     padding: 9px 0 4px 6px;
     background-color: @pane-background-color;


### PR DESCRIPTION
The (current) Atom project overview panel, has a tree view object which sets the style `contain` to `size`. By accident this matches to the rspec-tree-runner tree-view element...

This PR sets the `contain` CSS property back to `none` (only for this `tree-view`!)